### PR TITLE
Implement Dilation of Superpixels

### DIFF
--- a/code/data/superpixels.py
+++ b/code/data/superpixels.py
@@ -20,7 +20,9 @@ def compute_sp_FH(img):
     return seg
 
 
-def compute_mask(video, sp_method, num_components, p, randomise_superpixels, randomise_superpixels_range, compactness):
+def compute_mask(video, sp_method, num_components, p, 
+                 randomise_superpixels, randomise_superpixels_range, 
+                 compactness):
     sp_tensor_time = []
 
     if sp_method == "random":
@@ -36,10 +38,11 @@ def compute_mask(video, sp_method, num_components, p, randomise_superpixels, ran
             img = video[t, :, :, :]
             img = img.permute(1, 2, 0).cpu().numpy()
             if method == "slic":
-                low, high = num_components - randomise_superpixels_range//2, num_components + \
-                    randomise_superpixels_range//2
-                segments = compute_sp_slic(img, torch.randint(
-                    low=low, high=high, size=(1,)).item(), compactness)
+                low, high = (num_components - randomise_superpixels_range//2, 
+                             num_components + randomise_superpixels_range//2)
+                segments = compute_sp_slic(img, 
+                                           torch.randint(low=low, high=high, size=(1,)).item(), 
+                                           compactness)
             elif method == "fh":
                 segments = compute_sp_FH(img)
             sp_tensor_time.append(torch.from_numpy(segments))

--- a/code/train.py
+++ b/code/train.py
@@ -6,9 +6,10 @@ import numpy as np
 import json
 
 import torch
+from torch import nn
 import torch.utils.data
 from torch.utils.data.dataloader import default_collate
-from torch import nn
+
 import torchvision
 
 import data
@@ -32,16 +33,14 @@ torch.autograd.set_detect_anomaly(True)
 # train_one_epoch function
 ####################################################################################################
 
-
 def train_one_epoch(model, optimizer, lr_scheduler, data_loader, device,
-                    epoch, print_freq, vis=None, checkpoint_fn=None, prob=None):
+                    epoch, print_freq, vis=None, checkpoint_fn=None, 
+                    prob=None):
 
     model.train()
     metric_logger = utils.MetricLogger(delimiter="  ")
-    metric_logger.add_meter(
-        'lr', utils.SmoothedValue(window_size=1, fmt='{value}'))
-    metric_logger.add_meter(
-        'clips/s', utils.SmoothedValue(window_size=10, fmt='{value:.3f}'))
+    metric_logger.add_meter('lr', utils.SmoothedValue(window_size=1, fmt='{value}'))
+    metric_logger.add_meter('clips/s', utils.SmoothedValue(window_size=10, fmt='{value:.3f}'))
 
     header = f'Epoch: [{epoch}]'
 
@@ -56,14 +55,15 @@ def train_one_epoch(model, optimizer, lr_scheduler, data_loader, device,
 
         if grid:
             video = video.to(device)
-            output, loss, diagnostics = model(
-                video, None, None, None) if not args.teacher_student else model(video)
+            output, loss, diagnostics = model(video, None, None, orig_unnorm=None) if not args.teacher_student else model(video)
         else:
             sp_mask = sp_mask.to(device)
             orig = orig.to(device)
             max_sp_num = len(torch.unique(sp_mask))
-            output, loss, diagnostics = model(
-                orig, sp_mask, max_sp_num, orig_unnorm=orig_unnorm)
+            output, loss, diagnostics = model(orig, 
+                                              sp_mask, 
+                                              max_sp_num, 
+                                              orig_unnorm=orig_unnorm) 
 
         loss = loss.mean()
 
@@ -78,31 +78,23 @@ def train_one_epoch(model, optimizer, lr_scheduler, data_loader, device,
 
         optimizer.zero_grad()
         loss.backward()
-        # print(torch.nn.utils.clip_grad_norm_(model.parameters(), 1), 'grad norm')
         optimizer.step()
 
-        metric_logger.update(
-            loss=loss.item(), lr=optimizer.param_groups[0]["lr"])
-        metric_logger.meters['clips/s'].update(
-            video.shape[0] / (time.time() - start_time))
+        metric_logger.update(loss=loss.item(), lr=optimizer.param_groups[0]["lr"])
+        metric_logger.meters['clips/s'].update(video.shape[0] / (time.time() - start_time))
         lr_scheduler.step()
 
-        # CHANGE COMPACTNESS DURING THE EPOCH
+        # Change Compactness During The Epoch
         # if step > len(data_loader)//2 and epoch < 15:
         #     compactness = data_loader.dataset.get_compactness()
         #     data_loader.dataset.set_compactness(compactness - 10)
 
     checkpoint_fn()
 
-    # #### CHANGE COMPACTNESS EACH EPOCH
-    dict_compact = {0:120, 1:90, 2:70, 3:50, 4:35, 5:25}
-
-    if epoch in dict_compact.keys():
-        compactness = dict_compact[epoch]
-    else:
-        compactness = 20
-    
-    data_loader.dataset.set_compactness(compactness)
+    # # Change Compactness Each Epoch
+    # dict_compact = {0:120, 1:90, 2:70, 3:50, 4:35, 5:25}
+    # compactness = dict_compact.get(epoch, 20)
+    # data_loader.dataset.set_compactness(compactness)
 
     # if epoch < 10:
     #     compactness = data_loader.dataset.get_compactness()
@@ -124,8 +116,7 @@ def train_one_epoch(model, optimizer, lr_scheduler, data_loader, device,
 def _get_cache_path(filepath):
     import hashlib
     h = hashlib.sha1(filepath.encode()).hexdigest()
-    cache_path = os.path.join("~", ".torch", "vision",
-                              "datasets", "kinetics", h[:10] + ".pt")
+    cache_path = os.path.join("~", ".torch", "vision", "datasets", "kinetics", h[:10] + ".pt")
     cache_path = os.path.expanduser(cache_path)
     return cache_path
 
@@ -138,7 +129,6 @@ def collate_fn(batch):
 ####################################################################################################
 # Main
 ####################################################################################################
-
 
 def main(args):
 
@@ -157,8 +147,7 @@ def main(args):
     torch.backends.cudnn.benchmark = True
 
     print("Preparing training dataloader", end="\n"+"-"*100+"\n")
-    traindir = os.path.join(
-        args.data_path, 'train_256' if not args.fast_test else 'val_256')
+    traindir = os.path.join(args.data_path, 'train_256' if not args.fast_test else 'val_256')
     valdir = os.path.join(args.data_path, 'val_256')
 
     st = time.time()
@@ -188,9 +177,7 @@ def main(args):
             )
         # HACK assume image dataset if data path is a directory
         elif os.path.isdir(args.data_path):
-            return torchvision.datasets.ImageFolder(
-                root=args.data_path,
-                transform=_transform)
+            return torchvision.datasets.ImageFolder(root=args.data_path, transform=_transform)
         else:
             return VideoList(
                 filelist=args.data_path,
@@ -202,29 +189,24 @@ def main(args):
             )
 
     if args.cache_dataset and os.path.exists(cache_path):
-        print(
-            f"Loading dataset_train from {cache_path}", end="\n"+"-"*100+"\n")
+        print(f"Loading dataset_train from {cache_path}", end="\n"+"-"*100+"\n")
         dataset, _ = torch.load(cache_path)
         cached = dict(video_paths=dataset.video_clips.video_paths,
                       video_fps=dataset.video_clips.video_fps,
                       video_pts=dataset.video_clips.video_pts)
-
-        dataset = make_dataset(
-            is_train=True, cached=cached)
+        dataset = make_dataset(is_train=True, cached=cached)
         dataset.transform = transform_train
     else:
         dataset = make_dataset(is_train=True)
         if 'kinetics' in args.data_path.lower():  # args.cache_dataset and
-            print(
-                f"Saving dataset_train to {cache_path}", end="\n"+"-"*100+"\n")
+            print(f"Saving dataset_train to {cache_path}", end="\n"+"-"*100+"\n")
             utils.mkdir(os.path.dirname(cache_path))
             dataset.transform = None
             torch.save((dataset, traindir), cache_path)
             dataset.transform = transform_train
 
     if hasattr(dataset, 'video_clips'):
-        dataset.video_clips.compute_clips(
-            args.clip_len, 1, frame_rate=args.frame_skip)
+        dataset.video_clips.compute_clips(args.clip_len, 1, frame_rate=args.frame_skip)
 
     print("Took", time.time() - st)
 
@@ -240,10 +222,14 @@ def main(args):
     print("Creating data loaders", end="\n"+"-"*100+"\n")
     train_sampler = make_data_sampler(True, dataset)
 
-    data_loader = torch.utils.data.DataLoader(
-        dataset, batch_size=args.batch_size,  # shuffle=not args.fast_test,
-        sampler=train_sampler, num_workers=args.workers//2,
-        pin_memory=True, collate_fn=collate_fn)
+    data_loader = torch.utils.data.DataLoader(dataset, 
+                                              batch_size=args.batch_size, 
+                                              sampler=train_sampler, 
+                                              num_workers=args.workers//2,
+                                              pin_memory=True, 
+                                              collate_fn=collate_fn, 
+                                              #   shuffle=not args.fast_test,
+                                              )
 
     print("Set Compactness at:", args.compactness)
     data_loader.dataset.set_compactness(args.compactness)
@@ -256,8 +242,7 @@ def main(args):
     if not args.teacher_student:
         model = CRW(args, vis=vis).to(device)
     else:
-        model = CRWTeacherStudent(args, vis=None).to(
-            device)  # NOTE Disabled vis during prototyping
+        model = CRWTeacherStudent(args, vis=None).to(device)  # NOTE Disabled vis during prototyping
     # print(model)
 
     # Optimizer
@@ -265,9 +250,10 @@ def main(args):
 
     # Learning rate schedule
     lr_milestones = [len(data_loader) * m for m in args.lr_milestones]
-    lr_scheduler = torch.optim.lr_scheduler.MultiStepLR(
-        optimizer, milestones=lr_milestones, gamma=args.lr_gamma)
-
+    lr_scheduler = torch.optim.lr_scheduler.MultiStepLR(optimizer, 
+                                                        milestones=lr_milestones, 
+                                                        gamma=args.lr_gamma)
+    
     model_without_ddp = model
 
     # Parallelise model over GPUs
@@ -297,13 +283,10 @@ def main(args):
                 'optimizer': optimizer.state_dict(),
                 'lr_scheduler': lr_scheduler.state_dict(),
                 'epoch': epoch,
-                'args': args}
-            torch.save(
-                checkpoint,
-                os.path.join(args.output_dir, f'model_{epoch}.pth'))
-            torch.save(
-                checkpoint,
-                os.path.join(args.output_dir, 'checkpoint.pth'))
+                'args': args
+                }
+            torch.save(checkpoint, os.path.join(args.output_dir, f'model_{epoch}.pth'))
+            torch.save(checkpoint, os.path.join(args.output_dir, 'checkpoint.pth'))
 
     # Start Training
     print("Start training", end="\n"+"-"*100+"\n")
@@ -321,7 +304,6 @@ def main(args):
 ####################################################################################################
 # Run as Script
 ####################################################################################################
-
 
 if __name__ == "__main__":
     args = utils.arguments.train_args()

--- a/code/train.sh
+++ b/code/train.sh
@@ -12,19 +12,14 @@ cache_path_sample="/data_volume/data/cached_data/kinetics_sample.pt"
 # Core {Superpixels | Patches | Mix} Model Training
 ####################################################################################################
 
-python -W ignore train.py --data-path $path_to_kinetics \
---cache-dataset --cache-path $cache_path \
+python -W ignore train.py --data-path $path_to_kinetics_sample \
+--cache-dataset --cache-path $cache_path_sample \
 --frame-aug grid --dropout 0.1 --clip-len 4 --temp 0.05 \
---model-type "scratch" --workers 20 --batch-size 48 --lr 0.0003 \
---epochs 20 \
---sp-method slic --num-sp 16 --prob 0 \
---compactness 120 --data-parallel --output-dir "./checkpoints/sp_unnorm_scratch_16/" \
---visualize
-# --visualize --port 8094 \
-# --partial-reload "../pretrained.pth" 
-# --randomise-superpixels --data-parallel --port 8095
-# --output-dir "./checkpoints/randomise_sp_unnorm/"
-# --resume "./checkpoints/randomise_sp_unnorm/checkpoint.pth"
+--model-type "scratch" --workers 20 --batch-size 6 --lr 0.0003 \
+--epochs 20 --data-parallel \
+--sp-method slic --num-sp 36 --prob 0 \
+--compactness 50 \
+--dilate-superpixels --dilation-kernel-size 55 # NB --dilation-kernel-shape is 'L1' by default
 
 ####################################################################################################
 # Teacher-Student Training

--- a/code/utils/__init__.py
+++ b/code/utils/__init__.py
@@ -584,6 +584,30 @@ def view_as_windows(arr_in, window_shape, step=1):
     return arr_out
 
 #########################################################
+# Superpixel Mask Dilation: 2D Kernel creation functions
+#########################################################
+
+def make_dilation_kernel(args):
+    kernel_size, kernel_shape = args.dilation_kernel_size, args.dilation_kernel_shape
+    assert kernel_size % 2 != 0, "Use an odd kernel size"
+    kernel = torch.zeros(kernel_size, kernel_size, device=args.device, dtype=torch.float16)
+    center = kernel_size // 2
+    if kernel_shape == 'L1':
+        for i in range(kernel_size):
+            for j in range(kernel_size):
+                if (abs(center-i) + abs(center-j)) <= center:
+                    kernel[i, j] = 1
+    elif kernel_shape == 'cross':
+        kernel[:, center] = 1
+        kernel[center, :] = 1
+    elif kernel_shape == 'circle':
+        for i in range(kernel_size):
+            for j in range(kernel_size):
+                if ((center-i)**2 + (center-j)**2) <= center**2:
+                    kernel[i, j] = 1
+    return kernel
+
+#########################################################
 # Misc
 #########################################################
 

--- a/code/utils/arguments.py
+++ b/code/utils/arguments.py
@@ -204,6 +204,11 @@ def train_args():
     parser.add_argument('--compactness', default=200,
                         type=int, help='initial compactness')
 
+    # Dilated Superpixels
+    parser.add_argument('--dilate-superpixels', default=False, action='store_true', help='Dilate superpixels')
+    parser.add_argument('--dilation-kernel-shape', default='L1', type=str, help='L1 | circle | cross')
+    parser.add_argument('--dilation-kernel-size', default=51, type=int, help='Size of kernel used for dilation')
+
     # Variable Superpixels
     parser.add_argument('--randomise-superpixels', default=False, action='store_true',
                         help='Use a random sequence for the number of superpixel components (with SLIC)')

--- a/code/utils/visualize.py
+++ b/code/utils/visualize.py
@@ -110,9 +110,9 @@ class Visualize(object):
     def wandb_init(self, model):
         if not self._init:
             self._init = True
-            wandb.init(project="superpixels-no-norm",
+            wandb.init(project="dilated-superpixels",
                        entity="sapienzavideocontrastive",
-                       group="release",
+                       group="main",
                        config=self.args)
             wandb.watch(model)
 


### PR DESCRIPTION
This single commit contains all additional work to implement dilation of superpixel masks according to a dilation kernel (shape according to L1 distance, L2 (circle) or a cross kernel, setting post-dilation mask values to 1 when the superpixel is present in the central row or column of the kernel.

Kernel size defaults to 51 (and is forced to be an odd size).

Dilation is set via the dilate-superpixels argument, with kernel shape and size also set via args.

Implementation of the dilation is performed via a depthwise-separable 2D convolution. It might more aptly be named Binary Mask Dilation, as this is a special case where the dilation can be directly performed by convolution followed by a greater than zero comparison over the 2D convolved image